### PR TITLE
`SentencePieceProcessor`: `piece_to_id` throws when piece token is unknown

### DIFF
--- a/curated_tokenizers/tests/test_sp.py
+++ b/curated_tokenizers/tests/test_sp.py
@@ -1,6 +1,6 @@
 from pathlib import Path
-import pytest
 
+import pytest
 from curated_tokenizers import SentencePieceProcessor
 
 
@@ -148,7 +148,9 @@ def test_id_to_piece_and_piece_to_id(toy_model):
     assert toy_model.piece_to_id("<s>") == toy_model.bos_id()
     assert toy_model.piece_to_id("</s>") == toy_model.eos_id()
     assert toy_model.piece_to_id("<unk>") == toy_model.unk_id()
-    assert toy_model.piece_to_id("qotsa") == toy_model.unk_id()
+
+    with pytest.raises(ValueError):
+        toy_model.piece_to_id("qotsa")
 
     assert toy_model.id_to_piece(toy_model.bos_id()) == "<s>"
     assert toy_model.id_to_piece(toy_model.eos_id()) == "</s>"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->
Previously, we had the inconsistent behavior where `piece_to_id` would return the ID of the `unk` metatoken when the piece token was out-of-vocab, but `id_to_piece` would throw when an invalid piece ID was passed to it. This PR fixes that by making `piece_to_id` throw as well.

### Types of change

<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->
Refactor/enhancement

## Checklist

<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
